### PR TITLE
Change default API info to that used in the API Project

### DIFF
--- a/conf/securesocial.conf
+++ b/conf/securesocial.conf
@@ -53,9 +53,9 @@ securesocial {
 	google {
 		authorizationUrl="https://accounts.google.com/o/oauth2/auth"
 		accessTokenUrl="https://accounts.google.com/o/oauth2/token"
-		clientId="138261229938.apps.googleusercontent.com"
+		clientId="1091241109207-lse85ka6c715j47u539o4gi355oebu12.apps.googleusercontent.com"
 		clientId=${?GOOGLE_CLIENT_ID}
-		clientSecret="Q6J1rwV6TT50sJrca93gNeLs"
+		clientSecret="uJcCyqrTlDMcaoiMKwXF_sCK"
 		clientSecret=${?GOOGLE_CLIENT_SECRET}
 		scope="https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email"
 	}


### PR DESCRIPTION
This API client/secret for use with local are added to the same set as those used by staging and production.
