### PR TITLE
Creating endpoint for testing 'render' option

### DIFF
--- a/app/player/controllers/Views.scala
+++ b/app/player/controllers/Views.scala
@@ -130,16 +130,16 @@ class Views(auth: TokenizedRequestActionBuilder[RequestedAccess], val itemServic
   protected def renderItem(params: RenderParams) = auth.ValidatedAction(params.toRequestedAccess) {
     tokenRequest =>
       ApiAction {
-        implicit request => prepareHtml(params, params.itemId, request.ctx.organization) match {
+        implicit request => prepareHtml(params, request.ctx.organization) match {
           case Some(html: Html) => Ok(html).withSession(request.session + activeModeCookie(params.sessionMode))
           case None => NotFound("not found")
         }
       }(tokenRequest)
   }
 
-  protected def prepareHtml(params: RenderParams, itemId: VersionedId[ObjectId], orgId: ObjectId): Option[Html] =
+  protected def prepareHtml(params: RenderParams, orgId: ObjectId): Option[Html] =
     try {
-      getItemXMLByObjectId(itemId, orgId) match {
+      getItemXMLByObjectId(params.itemId, orgId) match {
         case Some(xmlData: Elem) => {
           val qtiKeys = QtiKeys((xmlData \ "itemBody")(0))
           val finalXml = prepareQti(xmlData, params.renderingMode)

--- a/conf/routes
+++ b/conf/routes
@@ -243,6 +243,6 @@ GET     /internal/utils/qti-search  internal.controllers.QtiSearch.qtiSearchPage
 POST    /internal/utils/qti-search  internal.controllers.QtiSearch.qtiSearch()
 
 # Regression test endpoints
-# Regression test endpoints
+GET     /regression/:orgId/:itemSessionId/render            regression.controllers.Item.renderPlayer(orgId: ObjectId, itemSessionId: ObjectId)
 GET     /regression/:orgId/:itemId/:requestedAccess         regression.controllers.Item.simplePlayer(requestedAccess: String, orgId: ObjectId, itemId: VersionedId[ObjectId])
 


### PR DESCRIPTION
The render option requires an item session, so the new endpoint operates using that.
