### PR TITLE
Add standards to NC items

### DIFF
--- a/deployment/migrations/0034_newclassrooms_add_standards.js
+++ b/deployment/migrations/0034_newclassrooms_add_standards.js
@@ -33,7 +33,5 @@ function up() {
         }
     });
 
-    print(noMatchCount);
+    print("Number of items with no match: " + noMatchCount);
 }
-
-up();


### PR DESCRIPTION
Used the following ruby script to generate the mappings and missing skill number list:

```
require 'csv'
require 'json'

NC_CODE = 0
CCSS = 5
CCSS_REGEX = /\(CC\) (.*)/

standards_map = {}
nc_no_standard = []

nc_weird_no_standard_message = "Enrichment Skill"

corespring_dot_notation = []
corespring_json = File.open('common-seed-data/ccstandards.json').each do |line|
  corespring_dot_notation << JSON.parse(line)['dotNotation']
end

CSV.foreach("newclassrooms/CC-Skills--2013-10-23.csv", headers: true) do |row|
  standards_map[row[NC_CODE]] = [] unless standards_map.has_key?(row[NC_CODE])
  unless row[CCSS].nil? || row[CCSS].empty?
    unless row[CCSS].match(CCSS_REGEX).nil?
      if row[CCSS].match(CCSS_REGEX)[1].strip == nc_weird_no_standard_message
        nc_no_standard << row[NC_CODE]
      else
        puts row[CCSS]
        nc_ccss = row[CCSS].match(CCSS_REGEX)[1].strip
        corespring_regex = Regexp.new((nc_ccss.split(".")[0..-2] << "(\\w+)" << nc_ccss.split(".")[-1]).join("\\.")+"$")
        corespring_notations = corespring_dot_notation.select{|d| d =~ corespring_regex}
        if corespring_notations.length > 1
          throw "New Classrooms CCSS value #{nc_ccss} matched more than one Corespring CCSS: #{corespring_notations}"
        elsif corespring_notations.length == 0
          throw "New Classrooms CCSS value #{nc_ccss} matched no Corespring CCSS"
        end
        standards_map[row[NC_CODE]] << corespring_notations.first
      end
    end
  end
end

puts standards_map.to_json
puts nc_no_standard.to_json
```

Script relies on following symlinks in the corespring-api folder:

```
ln -s ~/Google\ Drive/CoreSpring/03_Partners/New\ Classrooms_CoreSpring/ newclassrooms
ln -s conf/seed-data/common common-seed-data
```
