### PR TITLE
Responses w/o default correct not required in JS processing

### DIFF
--- a/modules/lib/core/src/main/scala/org/corespring/platform/core/models/itemSession/ResponseProcessingOutputValidator.scala
+++ b/modules/lib/core/src/main/scala/org/corespring/platform/core/models/itemSession/ResponseProcessingOutputValidator.scala
@@ -41,7 +41,7 @@ object ResponseProcessingOutputValidator {
     validateJsValue(jsValue) match {
       case Some(internalError) => Some(internalError)
       case _ => {
-        val identifiers = responseDeclarations.map(_.identifier)
+        val identifiers = responseDeclarations.filter(_.hasDefaultCorrectResponse).map(_.identifier)
         identifiers.find(identifier => (jsValue \ "identifierOutcomes" \ identifier).isInstanceOf[JsUndefined]) match {
           case Some(identifier) =>
             Some(InternalError(s"""Response for identifier $identifier is required in JsObject"""))

--- a/modules/lib/qti/src/main/scala/org/corespring/qti/models/QtiItem.scala
+++ b/modules/lib/qti/src/main/scala/org/corespring/qti/models/QtiItem.scala
@@ -235,6 +235,11 @@ case class ResponseDeclaration(identifier: String, cardinality: String, baseType
     case false => response.replaceAllLiterally(" ", "").toLowerCase
   }
 
+  def hasDefaultCorrectResponse = correctResponse match {
+    case None => false
+    case _ => true
+  }
+
 }
 
 object ResponseDeclaration {

--- a/modules/lib/qti/src/test/scala/org/corespring/qti/models/ResponseDeclarationTest.scala
+++ b/modules/lib/qti/src/test/scala/org/corespring/qti/models/ResponseDeclarationTest.scala
@@ -67,4 +67,21 @@ class ResponseDeclarationTest extends Specification {
 
   }
 
+  "hasDefaultCorrectResponse" should {
+
+    val mockResponseDeclaration = ResponseDeclaration(identifier = "identifier", cardinality = "single",
+      baseType = "something", exactMatch = false, correctResponse = None, mapping = None)
+
+    val mockCorrectResponse = CorrectResponseAny(<value>5</value>)
+
+    "return true when correctResponse is defined" in {
+      mockResponseDeclaration.copy(correctResponse = Some(mockCorrectResponse)).hasDefaultCorrectResponse must beTrue
+    }
+
+    "return false when correctResponse is not defined" in {
+      mockResponseDeclaration.copy(correctResponse = None).hasDefaultCorrectResponse must beFalse
+    }
+
+  }
+
 }


### PR DESCRIPTION
[#64592982]

This is done to support a use-case in which there are a bunch of items in a composite item that **do** have default or calculated responses, but the user would also like to include items which do not have a score by default (such as a `ExtendedTextInteraction` for additional comments from the student).
