### PR TITLE
update call - remove calls to super and resource

### DIFF
--- a/modules/lib/v2-player-integration/src/main/scala/org/corespring/v2player/integration/urls/ComponentSetsWired.scala
+++ b/modules/lib/v2-player-integration/src/main/scala/org/corespring/v2player/integration/urls/ComponentSetsWired.scala
@@ -1,13 +1,12 @@
 package org.corespring.v2player.integration.urls
 
-import org.corespring.container.client.component.{CatalogGenerator, EditorGenerator, PlayerGenerator, SourceGenerator}
+import org.corespring.container.client.component.{ CatalogGenerator, EditorGenerator, PlayerGenerator, SourceGenerator }
 import org.corespring.container.client.controllers.ComponentSets
 import org.corespring.container.components.model.Component
 import org.corespring.container.components.model.dependencies.DependencyResolver
-import play.api.cache.Cached
-import play.api.{Mode, Play}
 import play.api.cache.Cache
 import play.api.mvc._
+import play.api.{ Mode, Play }
 
 trait ComponentSetsWired extends ComponentSets {
 
@@ -16,25 +15,27 @@ trait ComponentSetsWired extends ComponentSets {
   }
 
   override def resource[A >: play.api.mvc.EssentialAction](context: scala.Predef.String, directive: scala.Predef.String, suffix: scala.Predef.String): A = {
-    if (Play.current.mode == Mode.Dev) {
-      super.resource(context, directive, suffix)
-    } else {
+
+    val bodyAndContentType: (String, String) = {
+
       implicit val current = play.api.Play.current
 
-      val cacheKey = s"$context-$directive-$suffix"
-
-      val res = Cache.get(cacheKey) match {
-        case Some(value) => value.asInstanceOf[(String, String)]
-        case None =>
-          val bodyAndContentType = super.generateBodyAndContentType(context, directive, suffix)
-          Cache.set(cacheKey, bodyAndContentType)
-          bodyAndContentType
-      }
-
-      Action {
-        Ok(res._1).as(res._2)
+      if (Play.current.mode == Mode.Dev) {
+        generateBodyAndContentType(context, directive, suffix)
+      } else {
+        val cacheKey = s"$context-$directive-$suffix"
+        Cache.get(cacheKey) match {
+          case Some(value) => value.asInstanceOf[(String, String)]
+          case None =>
+            val out = generateBodyAndContentType(context, directive, suffix)
+            Cache.set(cacheKey, out)
+            out
+        }
       }
     }
+
+    val (body, ct) = bodyAndContentType
+    Action(Ok(body).as(ct))
   }
 
   override def editorGenerator: SourceGenerator = new EditorGenerator


### PR DESCRIPTION
Quick tidy up on @amiklosi 's change
- client must implement `resource`
- tidy logic about getting cached or raw content.
