### PR TITLE
Inline feedback fix

### DIFF
--- a/public/js/corespring/qti/directives/web/choiceInteraction.js
+++ b/public/js/corespring/qti/directives/web/choiceInteraction.js
@@ -78,6 +78,15 @@ angular.module('qti.directives').directive('choiceinteraction', function () {
    */
   var compile = function (element, attrs, transclude) {
 
+    function wrapLabel(markup) {
+      var $markup = $('<div>' + markup + '</div>');
+      $('[simplechoice]', $markup).each(function(i, el) {
+        $(el).wrapInner('<div class="choice-label-container"></div>');
+      });
+      return $markup.html();
+    }
+
+
     var shuffle = attrs["shuffle"] === "true";
     var insertLetters = !(attrs["insertletters"] == "false");
     var isHorizontal = attrs["orientation"] === "horizontal";
@@ -91,6 +100,8 @@ angular.module('qti.directives').directive('choiceinteraction', function () {
       .replace(/<:*prompt>(.|[\r\n])*?<\/:*prompt>/gim, "")
       .replace(/<:*simpleChoice/gi, "<span simplechoice").replace(/<\/:*simpleChoice>/gi, "</span>")
       .replace(/<:*feedbackInline/gi, "<span feedbackinline").replace(/<\/:*feedbackInline>/gi, "</span>");
+
+    finalContents = wrapLabel(finalContents);
 
     var newNode = isHorizontal ?
       ('<div ng-class="{noResponse: noResponse}"><div class="choice-interaction">' + prompt + '<div class="choice-wrap">' + finalContents + '</div></div><div style="clear: both"></div></div>')

--- a/public/js/corespring/qti/directives/web/simpleChoice.js
+++ b/public/js/corespring/qti/directives/web/simpleChoice.js
@@ -35,7 +35,7 @@ angular.module('qti.directives').directive('simplechoice', function (QtiUtils) {
             var createFeedbackContainerDiv = function (html, returnContainerIfEmpty) {
                 var feedbackNodes = html.match(feedbackInlineRegex);
 
-                var feedbackContainer = "<div class='feedback-container {{correctClass}}'>" + emptyCells(2);
+                var feedbackContainer = "<div class='feedback-container {{correctClass}}'>" + emptyCells(1);
                 if (!feedbackNodes) {
                     return returnContainerIfEmpty ? feedbackContainer + "</div>" : "";
                 }

--- a/public/stylesheets/qti/directives/web/choiceInteraction.css
+++ b/public/stylesheets/qti/directives/web/choiceInteraction.css
@@ -153,7 +153,7 @@
 
 [feedbackinline] span {
   padding: 15px 0 15px 35px;
-  margin-left: -40px;
+  margin-left: -10px;
 }
 
 .incorrect-response [feedbackinline],


### PR DESCRIPTION
This makes the feedback a `display: table-row` so that its content isn't squished in between choices and its height guessed at `40px`.
