### PR TITLE
Add spacing to v2 preview, since no bar from player

### DIFF
--- a/app/assets/stylesheets/app.less
+++ b/app/assets/stylesheets/app.less
@@ -250,6 +250,10 @@
     .preview{
         position: absolute;
 
+        .v2 #iframe-player {
+            margin-top: 40px;
+        }
+
         background-image: url('/assets/images/corrugated-bg.png');
         .mixin-inner-shadow(3px, fade(#000000, 20%));
         top: 0px;

--- a/app/web/views/partials/editItem.scala.html
+++ b/app/web/views/partials/editItem.scala.html
@@ -234,7 +234,7 @@
                     <a href="{{fullPreviewUrl}}" target="_blank" >Preview in new window</a>
                 </div>
 
-                <div class="preview-container" id="item-preview-target"></div>
+                <div class="preview-container" ng-class="{'v2': isV2()}" id="item-preview-target"></div>
             </div>
         </div>
         <a class="other-version" ng-click="changePlayerVersion()">v{{otherPlayerVersion()}} player</a>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val playVersion = "2.2.1"
 
   //V2 Player
-  val containerVersion = "0.11.0-SNAPSHOT"
+  val containerVersion = "0.11.2"
   val containerClientWeb = "org.corespring" %% "container-client-web" % containerVersion
   val containerJsProcessing = "org.corespring" %% "js-processing" % containerVersion
   val componentModel = "org.corespring" %% "component-model" % containerVersion


### PR DESCRIPTION
Add a `margin-top` to the preview when the player is v2. This is because there is currently no control bar (preview or settings) displayed, and the `position: absolute` preview button from the app will overlap the player if we don't do this.
