### PR TITLE
Check isPrivate flag as well as isPublic

### DIFF
--- a/modules/lib/core/src/main/scala/org/corespring/platform/core/models/ContentCollection.scala
+++ b/modules/lib/core/src/main/scala/org/corespring/platform/core/models/ContentCollection.scala
@@ -40,6 +40,7 @@ case class ContentCollection(
 object ContentCollection extends ModelCompanion[ContentCollection, ObjectId] with Searchable with ClassLogging {
   val name = "name"
   val isPublic = "isPublic"
+  val isPrivate = "isPrivate"
   val ownerOrgId = "ownerOrgId"
   val DEFAULT = "default" //used as the value for name when the content collection is a default collection
 
@@ -143,7 +144,9 @@ object ContentCollection extends ModelCompanion[ContentCollection, ObjectId] wit
     seqcollid
   }
 
-  def getPublicCollections: Seq[ContentCollection] = ContentCollection.find(MongoDBObject(isPublic -> true)).toSeq
+  def getPublicCollections: Seq[ContentCollection] = ContentCollection.find(
+    MongoDBObject("$or" -> Seq(MongoDBObject(isPublic -> true), MongoDBObject(isPrivate -> false)))).toSeq
+
   def isPublic(collectionId: ObjectId): Boolean = getPublicCollections.map(_.id).contains(collectionId)
 
   /**


### PR DESCRIPTION
Had to add this because we had a collection with `isPrivate` instead of `isPublic` in the database, and it was creating some confusion:

```
{
    "_id" : ObjectId("504e70d1e4b07f3e2e43236b"),
    "description" : "Items to test Feedback",
    "isPrivate" : false,
    "name" : "Test Items",
    "ownerOrgId" : ObjectId("502404dd0364dc35bb393398")
}
```

I'm not super happy about the fact that this change cannot be unit tested. The reason is that `ContentCollection` is an object, and the method it's calling is on itself. You can't mock methods on a Scala object, so there's no way to test if the other method is being called.
