### PR TITLE
Define rigorous unit test for BasicScoreService

### DIFF
--- a/modules/web/v2-api/test/org/corespring/v2/api/services/BasicScoreServiceTest.scala
+++ b/modules/web/v2-api/test/org/corespring/v2/api/services/BasicScoreServiceTest.scala
@@ -13,25 +13,38 @@ class BasicScoreServiceTest extends Specification with Mockito {
 
   class scoreScope extends Scope {
 
+    val playerDefinition =  PlayerDefinition(
+      files = Seq.empty,
+      xhtml = "<html/>",
+      components = Json.obj(),
+      summaryFeedback = "",
+      customScoring = None)
+
+    val answers = Json.obj("these" -> "are", "the" -> "answers")
+    val outcome = Json.obj("this" -> "is", "the" -> "outcome")
+    val score = Json.obj("this" -> "is", "the" -> "score")
+
     lazy val outcomeProcessor = mock[OutcomeProcessor]
+    outcomeProcessor.createOutcome(Json.toJson(playerDefinition), Json.obj("components" -> answers), Json.obj()) returns outcome
+
     lazy val scoreProcessor = {
       val m = mock[ScoreProcessor]
-      m.score(any[JsValue], any[JsValue], any[JsValue]) returns Json.obj()
+      m.score(any[JsValue], any[JsValue], any[JsValue]) returns score
       m
     }
     lazy val service = new BasicScoreService(outcomeProcessor, scoreProcessor)
+    val response = service.score(playerDefinition, answers)
   }
 
-  "BasicScoreService" should {
+  "score" should {
 
-    "work" in new scoreScope() {
-      val playerDefinition =  PlayerDefinition(
-          files = Seq.empty,
-          xhtml = "<html/>",
-          components = Json.obj(),
-          summaryFeedback = "",
-          customScoring = None)
-      service.score(playerDefinition, Json.obj()) must_== Success(Json.obj())
+    "call ScoreProcessor with itemJson, componentAnswers, and outcome" in new scoreScope {
+      there was one(scoreProcessor).score(Json.toJson(playerDefinition), Json.obj("components" -> answers), outcome)
     }
+
+    "return score from ScoreProcessor with success" in new scoreScope {
+      response must be equalTo(Success(score))
+    }
+
   }
 }


### PR DESCRIPTION
This is a far better unit test than we had before. The output of the previous unit test was this:

```
[info] BasicScoreServiceTest
[info] BasicScoreServiceTest should
[info] + work
[info] Total for specification BasicScoreServiceTest
[info] Finished in 295 ms
[info] 1 example, 0 failure, 0 error
```

Why is the output for this bad? It doesn't tell us anything about how the test meets our expectations. It says "BasicScoreServiceTest should work". This goes without saying, and it doesn't tell us about anything that the test is _actually testing_. The "should" description is also not useful&mdash;we know that we're testing `BasicScoreService` from the name of the test.

After this update, the output of the unit test looks as follows:

```
[info] BasicScoreServiceTest
[info] score should
[info] + call ScoreProcessor with itemJson, componentAnswers, and outcome
[info] + return score from ScoreProcessor with success
[info] Total for specification BasicScoreServiceTest
[info] Finished in 569 ms
[info] 2 examples, 0 failure, 0 error
```

Ah! Now we know that what we're asserting is that `BasicScoreService` delegates to the `ScoreProcessor` with a specific set of parameters (which were incorrect previously, hence the update to this unit test). We can also see that the response from the route should be a Success with the contents returned from the `ScoreProcessor`. Finally we can see from this that these tests are related to the `#score` method of `BasicScoreService`.
