### PR TITLE
add failing test for v2.ItemSessionApi.loadScore

### DIFF
--- a/it/org/corespring/v2/api/ItemSessionApiTest.scala
+++ b/it/org/corespring/v2/api/ItemSessionApiTest.scala
@@ -67,29 +67,29 @@ class ItemSessionApiTest extends IntegrationSpecification {
 
     }
 
-    "when calling load score" should {
+    def playerDef(customScoring: Option[String] = None) = PlayerDefinition(
+      Seq.empty,
+      "html",
+      Json.obj(
+        "1" -> Json.obj(
+          "componentType" -> "corespring-multiple-choice",
+          "correctResponse" -> Json.obj("value" -> Json.arr("carrot")),
+          "model" -> Json.obj(
+            "config" -> Json.obj(
+              "singleChoice" -> true),
+            "prompt" -> "Carrot?",
+            "choices" -> Json.arr(
+              Json.obj("label" -> "carrot", "value" -> "carrot"),
+              Json.obj("label" -> "banana", "value" -> "banana"))))),
+      "",
+      customScoring)
 
-      def playerDef = PlayerDefinition(
-        Seq.empty,
-        "html",
-        Json.obj(
-          "1" -> Json.obj(
-            "componentType" -> "corespring-multiple-choice",
-            "correctResponse" -> Json.obj("value" -> Json.arr("carrot")),
-            "model" -> Json.obj(
-              "config" -> Json.obj(
-                "singleChoice" -> true),
-              "prompt" -> "Carrot?",
-              "choices" -> Json.arr(
-                Json.obj("label" -> "carrot", "value" -> "carrot"),
-                Json.obj("label" -> "banana", "value" -> "banana"))))),
-        "",
-        None)
+    "when calling load score" should {
 
       s"return $OK and 100% - for multiple choice" in new token_loadScore(AnyContentAsJson(Json.obj())) {
 
         val item = ItemServiceWired.findOneById(itemId).get
-        val update = item.copy(playerDefinition = Some(playerDef))
+        val update = item.copy(playerDefinition = Some(playerDef()))
         val resultString = s"""{"summary":{"maxPoints":1,"points":1.0,"percentage":100.0},"components":{"1":{"weight":1,"score":1.0,"weightedScore":1.0}}}"""
         val resultJson = Json.parse(resultString)
         ItemServiceWired.save(update)
@@ -101,7 +101,7 @@ class ItemSessionApiTest extends IntegrationSpecification {
 
       s"return $OK and 0% - for multiple choice" in new token_loadScore(AnyContentAsJson(Json.obj())) {
         val item = ItemServiceWired.findOneById(itemId).get
-        val update = item.copy(playerDefinition = Some(playerDef))
+        val update = item.copy(playerDefinition = Some(playerDef()))
         val resultString = s"""{"summary":{"maxPoints":1,"points":0.0,"percentage":0.0},"components":{"1":{"weight":1,"score":0.0,"weightedScore":0.0}}}"""
         val resultJson = Json.parse(resultString)
         ItemServiceWired.save(update)
@@ -110,6 +110,34 @@ class ItemSessionApiTest extends IntegrationSpecification {
         status(result) === OK
         contentAsJson(result) === resultJson
       }
+    }
+
+    "when calling load score with a custom scoring item" should {
+
+      val customScoring = """
+      exports.process = function(item, session){
+        if(session.components[1].answers.indexOf('carrot') !== -1){
+          return { summary: { numcorrect: 1, score: 1.0}};
+        } else {
+          return { summary: { numcorrect: 0, score: 0}};
+        }
+      }
+      """
+
+      s"return $OK and 100% - for multiple choice" in new token_loadScore(AnyContentAsJson(Json.obj())) {
+
+        val item = ItemServiceWired.findOneById(itemId).get
+        val update = item.copy(playerDefinition = Some(playerDef(Some(customScoring))))
+        val resultString =
+          s"""{ "components":{"1":{"weight":1,"score":1.0,"weightedScore":1.0}}, "summary":{"numcorrect" : 1, "score" : 1.0}}"""
+        val resultJson = Json.parse(resultString)
+        ItemServiceWired.save(update)
+        V2SessionHelper.update(sessionId, Json.obj("itemId" -> itemId.toString, "components" -> Json.obj(
+          "1" -> Json.obj("answers" -> Json.arr("carrot")))))
+        status(result) === OK
+        contentAsJson(result) === resultJson
+      }
+
     }
   }
 


### PR DESCRIPTION
This Integration test was passing when custom scoring wasn't in use, but will fail now because the `scoreProcessor` gets the wrong object format passed into it.
