### PR TITLE
handle empty values gracefully when deserializing the dbo

### DIFF
--- a/modules/lib/core/src/main/scala/org/corespring/platform/core/models/item/PlayerDefinition.scala
+++ b/modules/lib/core/src/main/scala/org/corespring/platform/core/models/item/PlayerDefinition.scala
@@ -110,23 +110,29 @@ class PlayerDefinitionTransformer(val ctx: Context) extends CustomTransformer[Pl
 
   override def deserialize(b: DBObject): PlayerDefinition = try {
 
-    logger.trace(s"deserialize: ${b}")
-
-    val json: JsValue = ToJsValue(b.get("components"))
     import com.mongodb.casbah.Implicits._
 
-    val l = b.get("files").asInstanceOf[BasicDBList]
-    val prepped: Seq[BaseFile] = l.toList.map {
-      dbo => grater[BaseFile](ctx, manifest[BaseFile]).asObject(dbo.asInstanceOf[DBObject])
+    logger.trace(s"deserialize: ${b}")
+
+    val json: JsValue = if (b.get("components") == null) Json.obj() else ToJsValue(b.get("components"))
+
+    val files = if (b.get("files") == null || !b.get("files").isInstanceOf[BasicDBList]) {
+      Seq.empty
+    } else {
+      val list = b.get("files").asInstanceOf[BasicDBList]
+      list.toList.map {
+        dbo => grater[BaseFile](ctx, manifest[BaseFile]).asObject(dbo.asInstanceOf[DBObject])
+      }
     }
 
-    val customScoring = if (b.get("customScoring") != null) Some(b.get("customScoring").asInstanceOf[String]) else None
-
+    val customScoring = if (b.get("customScoring") == null) None else Some(b.get("customScoring").asInstanceOf[String])
+    val summaryFeedback = if (b.get("summaryFeedback") == null) "" else b.get("summaryFeedback").asInstanceOf[String]
+    val xhtml = if (b.get("xhtml") == null) "" else b.get("xhtml").asInstanceOf[String]
     new PlayerDefinition(
-      prepped,
-      b.get("xhtml").asInstanceOf[String],
+      files,
+      xhtml,
       json,
-      b.get("summaryFeedback").asInstanceOf[String],
+      summaryFeedback,
       customScoring)
   } catch {
     case e: Throwable => {

--- a/modules/lib/core/src/test/scala/org/corespring/platform/core/models/item/PlayerDefinitionTransformerTest.scala
+++ b/modules/lib/core/src/test/scala/org/corespring/platform/core/models/item/PlayerDefinitionTransformerTest.scala
@@ -96,6 +96,32 @@ class PlayerDefinitionTransformerTest extends Specification {
       deserialized === pd
     }
 
+    "with an empty dbo" should {
+      val dbo = MongoDBObject()
+      val pd = new PlayerDefinitionTransformer(mongoContext.context).deserialize(dbo)
+
+      "set summaryFeedback to an empty string" in {
+        pd.summaryFeedback === ""
+      }
+
+      "set customScoring to None" in {
+        pd.customScoring === None
+      }
+
+      "set files to empty list" in {
+        pd.files === Seq.empty
+      }
+
+      "set xhtml to an empty string" in {
+        pd.xhtml === ""
+      }
+
+      "set json to an empty object" in {
+        pd.components === Json.obj()
+      }
+
+    }
+
   }
 
   class serialize(val pd: PlayerDefinition, val dbo: DBObject) extends Scope {


### PR DESCRIPTION
- The deserialization should accommodate potential null values in the dbo gracefully.
