### PR TITLE
allow any version of a given id if no id is specified in settings

### DIFF
--- a/modules/lib/v2-auth/src/test/scala/org/corespring/v2/auth/models/PlayerAccessSettingsTest.scala
+++ b/modules/lib/v2-auth/src/test/scala/org/corespring/v2/auth/models/PlayerAccessSettingsTest.scala
@@ -1,14 +1,28 @@
 package org.corespring.v2.auth.models
 
+import org.bson.types.ObjectId
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
 
 class PlayerAccessSettingsTest extends Specification {
 
+  val oid = ObjectId.get.toString
   "allowItemId" should {
     "allow itemId when starred" in PlayerAccessSettings("*", Some("*"), false).allowItemId("?") === true
-    "not allow itemId when not starred" in PlayerAccessSettings("1", Some("*"), false).allowItemId("?") === false
-    "allow itemId when not starred" in PlayerAccessSettings("1", Some("*"), false).allowItemId("1") === true
+    "not allow itemId when not starred" in PlayerAccessSettings(oid, Some("*"), false).allowItemId("?") === false
+    "allow itemId when not starred" in PlayerAccessSettings(oid, Some("*"), false).allowItemId(oid) === true
+    "allow any versioned itemId when settings.itemId has only the id specified" in {
+      val settings = PlayerAccessSettings(oid, Some("*"), false)
+      settings.allowItemId(s"$oid:0") === true
+      settings.allowItemId(s"$oid:1") === true
+      settings.allowItemId(s"$oid:100") === true
+    }
+    "only allow a versioned itemId when settings.itemId has a version" in {
+      val settings = PlayerAccessSettings(s"$oid:0", Some("*"), false)
+      settings.allowItemId(s"$oid:0") === true
+      settings.allowItemId(s"$oid:1") === false
+      settings.allowItemId(s"$oid:100") === false
+    }
   }
 
   "allowSessionId" should {


### PR DESCRIPTION
If the `PlayerAccessSettings.itemId` has no version, allow any `VersionedId` that has the same id, but any version.
