### PR TITLE
Re-add support for querying by id

### DIFF
--- a/modules/lib/core/src/main/scala/org/corespring/platform/core/services/item/ItemIndexQuery.scala
+++ b/modules/lib/core/src/main/scala/org/corespring/platform/core/services/item/ItemIndexQuery.scala
@@ -132,10 +132,17 @@ object ItemIndexQuery {
         "query" -> (query.text match {
           case Some("") => None
           case Some(text) => Some(Json.obj(
-            "multi_match" -> Json.obj(
-              "query" -> text,
-              "fields" -> Seq("taskInfo.description", "taskInfo.title", "content"),
-              "type" -> "phrase"
+            "bool" -> Json.obj(
+              "should" -> Json.arr(
+                Json.obj("multi_match" -> Json.obj(
+                  "query" -> text,
+                  "fields" -> Seq("taskInfo.description", "taskInfo.title", "content"),
+                  "type" -> "phrase"
+                )),
+                Json.obj("ids" -> Json.obj(
+                  "values" -> Json.arr(text)
+                ))
+              )
             )
           ))
           case _ => None


### PR DESCRIPTION
Essentially what was happening before was that `phrase` querying was being applied to `taskInfo.title`, `taskInfo.description`, and `content` with a `multi_match` query to support all of those fields, this looked like:

```
{
  "multi_match" : {
      "query" : "Hey this is my query",
      "fields" : ["taskInfo.description", "taskInfo.title", "content"],
      "type" : "phrase"
  }
}
```

This change, however, no longer queries the `id` field of the ElasticSearch result. Before we were using a `simple_query_string_query`, which basically queries all indexed values... so now that we are more constrained we were missing the `id` field. The solution is to use a boolean query with `should` clauses to match on _either_ `id` _or_ the result of the `multi_match` fields:

```
{
  "bool" : {
    "should" : [
      {
        "multi_match" : {
          "query" : "Hey this is my query",
          "fields" : ["taskInfo.description", "taskInfo.title", "content"],
          "type" : "phrase"
      },
      {
        "ids" : {
          "values" : ["Hey this is my query"]
        }
      }
    ]
  }
}
```

You can't directly include the `id` field in the `multi_match` piece of the query, as it's not technically a document field, it's part of the metadata.
