### PR TITLE
remove access to Object methods bc it failsin the test

### DIFF
--- a/modules/lib/v2-auth/src/main/scala/org/corespring/v2/auth/AccessSettingsCheck.scala
+++ b/modules/lib/v2-auth/src/main/scala/org/corespring/v2/auth/AccessSettingsCheck.scala
@@ -39,7 +39,7 @@ class AccessSettingsWildcardCheck(appConfig: AppConfig) {
           logger.trace(s"itemId? $itemId -> ${settings.allowItemId(itemId)}")
           sessionId.foreach { sid => logger.trace(s"sessionId? $sid -> ${settings.allowSessionId(sid)}")}
           logger.trace(s"allowMode? $mode -> ${settings.allowMode(mode)}")
-          Failure(AccessSettingsWildcardCheck.notGrantedError(itemId, sessionId, settings))
+          Failure(notGrantedError(itemId, sessionId, settings))
         }
       }
       result

--- a/modules/lib/v2-auth/src/test/scala/org/corespring/v2/auth/AccessSettingsWildcardCheckTest.scala
+++ b/modules/lib/v2-auth/src/test/scala/org/corespring/v2/auth/AccessSettingsWildcardCheckTest.scala
@@ -1,14 +1,24 @@
 package org.corespring.v2.auth
 
+import org.corespring.common.config.AppConfig
 import org.corespring.v2.auth.models.{ Mode, PlayerAccessSettings }
+import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
+import play.api.Configuration
 
 import scalaz.{ Failure, Success }
 
-class AccessSettingsWildcardCheckTest extends Specification {
+class AccessSettingsWildcardCheckTest extends Specification with Mockito {
 
   import AccessSettingsWildcardCheck.notGrantedError
-  val allow = AccessSettingsWildcardCheck.allow _
+
+  val config = mock[Configuration]
+  config.getString(anyString, any) returns Some("test")
+  config.getBoolean(anyString) returns Some(false)
+  val appConfig = new AppConfig(config)
+  val check = new AccessSettingsWildcardCheck(appConfig)
+  val allow = check.allow _
+  val notGrantedError = check.notGrantedError _
 
   "allow" should {
 
@@ -17,7 +27,7 @@ class AccessSettingsWildcardCheckTest extends Specification {
     }
 
     "not allow if bad item id" in {
-      allow("*", Some("*"), Mode.view, PlayerAccessSettings("1", Some("*"), false)) must_== Failure(notGrantedError("*", Some("*"), PlayerAccessSettings("1", Some("*"), false)))
+      check.allow("*", Some("*"), Mode.view, PlayerAccessSettings("1", Some("*"), false)) must_== Failure(notGrantedError("*", Some("*"), PlayerAccessSettings("1", Some("*"), false)))
     }
 
     "not allow if bad session id" in {


### PR DESCRIPTION
The test was failing, because it was accessing the Object instance, which couldn't be properly instantiated. 
I changed the test to use an instance instead. 
Also in the class i removed one call via the object 
