### PR TITLE
PE-345 expand search filter

### DIFF
--- a/it/org/corespring/platform/core/services/StandardQueryServiceIntegrationTest.scala
+++ b/it/org/corespring/platform/core/services/StandardQueryServiceIntegrationTest.scala
@@ -12,7 +12,6 @@ class StandardQueryServiceIntegrationTest extends IntegrationSpecification {
 
     def makeQuery(s: String) = Json.obj("searchTerm" -> s).toString()
 
-    ""
     "be able to find single items" in new StandardData("some test standard") {
       val result = StandardQueryService.query(makeQuery("some test"))
       result.length === 1

--- a/modules/lib/core/src/main/scala/org/corespring/platform/core/services/StandardQueryBuilder.scala
+++ b/modules/lib/core/src/main/scala/org/corespring/platform/core/services/StandardQueryBuilder.scala
@@ -4,7 +4,7 @@ import com.mongodb.DBObject
 import com.mongodb.casbah.commons.MongoDBObject
 import play.api.libs.json.{ JsValue, Json, JsObject }
 
-trait StandardQueryBuilder {
+private[services] trait StandardQueryBuilder {
 
   lazy val searchTermKeys = Seq("standard", "subject", "category", "subCategory", "dotNotation")
 

--- a/modules/lib/core/src/main/scala/org/corespring/platform/core/services/StandardQueryService.scala
+++ b/modules/lib/core/src/main/scala/org/corespring/platform/core/services/StandardQueryService.scala
@@ -1,11 +1,8 @@
 package org.corespring.platform.core.services
 
-import com.mongodb.DBObject
-import com.mongodb.casbah.commons.{ MongoDBList, MongoDBObject }
 import org.bson.types.ObjectId
 import org.corespring.common.log.PackageLogging
-import org.corespring.platform.core.models.{ Standard, Subject }
-import play.api.libs.json.{ JsObject, JsSuccess, JsValue, Json }
+import org.corespring.platform.core.models.{ Standard }
 
 object StandardQueryService extends QueryService[Standard] with StandardQueryBuilder with PackageLogging {
 


### PR DESCRIPTION
The old logic to generate the mongo query object was not generating anything if `searchTerm` wasn't present, however `searchTerm` isn't mandatory. Some clean up + tests while I was in there too.
