### PR TITLE
AC-206 add tests for access token service

### DIFF
--- a/modules/core/services-salat/src/it/scala/org/corespring/services/salat/auth/AccessTokenServiceTest.scala
+++ b/modules/core/services-salat/src/it/scala/org/corespring/services/salat/auth/AccessTokenServiceTest.scala
@@ -5,7 +5,6 @@ import org.corespring.models.auth.AccessToken
 import org.corespring.services.salat.ServicesSalatIntegrationTest
 import org.joda.time.DateTime
 import org.specs2.mutable.BeforeAfter
-import org.specs2.specification.Outside
 
 import scalaz.Success
 
@@ -32,12 +31,13 @@ class AccessTokenServiceTest extends ServicesSalatIntegrationTest {
     }
 
     def mkToken(
+      scope: Option[String] = None,
       neverExpire: Option[Boolean] = None,
       creationDate: Option[DateTime] = None,
       expirationDate: Option[DateTime] = None) = {
       val token = AccessToken(
         ObjectId.get,
-        None,
+        scope,
         ObjectId.get.toString,
         neverExpire = neverExpire.getOrElse(false),
         creationDate = creationDate.getOrElse(DateTime.now),
@@ -79,8 +79,8 @@ class AccessTokenServiceTest extends ServicesSalatIntegrationTest {
       service.find(org.id, None) must_== token
     }
     "return token for org and scope" in new scope {
-      //TODO How to add scope to access token?
-      //service.find(org.id, Some("test-scope")) must_== token
+      val t = mkToken(scope=Some("test-scope"))
+      service.find(t.organization, Some("test-scope")) must_== Some(t)
     }
     "return None when org is not correct" in new scope {
       service.find(ObjectId.get, None) must_== None
@@ -89,32 +89,6 @@ class AccessTokenServiceTest extends ServicesSalatIntegrationTest {
       service.find(org.id, Some("test-scope")) must_== None
     }
 
-  }
-  "findById" should {
-    //@deprecated
-    "work" in pending
-  }
-  "findByOrgId" should {
-    "return the token if it is not expired" in new scope {
-      service.findByOrgId(org.id) must_== token
-    }
-    "create a new token if it is expired" in new scope {
-      //TODO Create? Really? Maybe a name change would be good to signal that
-      val expiredToken = mkExpiredToken()
-      val res = service.findByOrgId(expiredToken.organization)
-      res.isDefined must_== true
-      res must_!= expiredToken
-
-    }
-    "create a new token if it does not exist" in new scope {
-      //TODO Create? Really? Maybe a name change would be good to signal that
-      val orgTwo = insertOrg("2")
-      service.findByOrgId(orgTwo.id).isDefined must_== true
-    }
-  }
-  "findByToken" should {
-    //@deprecated
-    "work" in pending
   }
   "findByTokenId" should {
     "return the token for an id" in new scope {
@@ -144,10 +118,6 @@ class AccessTokenServiceTest extends ServicesSalatIntegrationTest {
     }
   }
 
-  "getTokenForOrgById" should {
-    //@deprecated
-    "work" in pending
-  }
   "insertToken" should {
     "insert a token as is" in new scope {
       val t = mkToken()

--- a/modules/core/services/src/main/scala/org/corespring/services/auth/AccessTokenService.scala
+++ b/modules/core/services/src/main/scala/org/corespring/services/auth/AccessTokenService.scala
@@ -20,12 +20,6 @@ trait AccessTokenService {
    */
   def findByTokenId(tokenId: String): Option[AccessToken]
 
-  @deprecated("use findByTokenId instead", "0.1")
-  def findByToken(token: String) = findByTokenId(token)
-
-  @deprecated("use findByTokenId instead", "0.1")
-  final def findById(token: String) = findByTokenId(token)
-
   /**
    * Finds an access token by organization and scope
    *
@@ -34,11 +28,6 @@ trait AccessTokenService {
    * @return returns an Option[AccessToken]
    */
   def find(orgId: ObjectId, scope: Option[String]): Option[AccessToken]
-
-  @deprecated("use findByOrgId", "0.1")
-  def getTokenForOrgById(id: ObjectId): Option[AccessToken]
-
-  def findByOrgId(id: ObjectId): Option[AccessToken]
 
   /**
    * Creates an access token to invoke the APIs protected by BaseApi.


### PR DESCRIPTION
1. added tests for the whole api but the deprecated ones
2. replaced direct AccessToken creation with calls to mkToken to reduce duplication
3. removed the call to ConfigFactory.load().getString("TOKEN_DURATION") bc. we get this from config.tokenDurationInHours
4. added dao.collection.writeConcern to the dao.insert call 
5. getOrCreateToken was using orgId instead of organization as the key, fixed that 

Notes: 
findByOrgId creates tokens, if they are expired or non existent, that doesn't look right. 
I think it should be renamed or changed 

getOrCreate and findByOrgId seem to be almost the same
