### PR TITLE
AC-206 add tests for standard service

### DIFF
--- a/modules/core/services-salat/src/it/scala/org/corespring/services/salat/StandardServiceTest.scala
+++ b/modules/core/services-salat/src/it/scala/org/corespring/services/salat/StandardServiceTest.scala
@@ -1,11 +1,11 @@
 package org.corespring.services.salat
 
-import com.mongodb.casbah.commons.MongoDBObject
-import org.corespring.models.{ Domain, StandardDomains, Standard }
+import org.bson.types.ObjectId
+import org.corespring.models.{Domain, Standard, StandardDomains}
 import org.corespring.services.StandardQuery
-import org.specs2.mutable.{ Before }
+import org.specs2.mutable.BeforeAfter
 import org.specs2.time.NoTimeConversions
-import play.api.libs.json.Json
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -13,7 +13,9 @@ class StandardServiceTest extends ServicesSalatIntegrationTest with NoTimeConver
 
   import Standard.Subjects._
 
-  trait scope extends Before {
+  trait scope extends BeforeAfter {
+
+    val service = services.standardService
 
     def addStandard(subject: String, category: String, dotNotation: String): Standard = {
       val s: Standard = Standard(
@@ -21,52 +23,40 @@ class StandardServiceTest extends ServicesSalatIntegrationTest with NoTimeConver
         category = Some(category),
         subCategory = Some(category),
         dotNotation = Some(dotNotation))
-      val id = services.standardService.insert(s).get
+      val id = service.insert(s).get
       s.copy(id = id)
     }
 
     override def before: Any = {
-      removeAllData()
       addStandard(ELA, "ela-1", "C.1.2")
       addStandard(ELA, "ela-1", "C.1")
       addStandard(ELA, "ela-1", "C.1.1")
       addStandard(ELA, "ela-2", "C.2")
       logger.debug(s"function=before - standard insertion complete")
     }
-  }
 
-  "query(StandardQuery)" should {
-
-    "return a list of standards when term is found in dotNotation" in new scope {
-      val query = StandardQuery("C.1.2", None, None, None, None)
-      val stream = services.standardService.query(query, 0, 0)
-      stream.length === 1
-    }
-
-    "return an empty list of standards when term is found in dotNotation, but the category filter is wrong" in new scope {
-      val query = StandardQuery("C.1.2", None, None, Some(Math), None)
-      val stream = services.standardService.query(query, 0, 0)
-      stream.length === 0
-    }
-  }
-
-  class StandardData(val standard: Any*) extends Before {
-
-    def toStandard(values: Any*) = values.map((v: Any) => v match {
-      case s: String => Standard(
-        dotNotation = Some(s),
-        subject = Some(s),
-        category = Some(s),
-        subCategory = Some(s),
-        standard = Some(s))
-      case o: Standard => o
-    })
-
-    override def before: Any = {
+    override def after = {
       removeAllData()
-      toStandard(standard: _*).flatMap { s =>
-        services.standardService.insert(s)
-      }
+    }
+  }
+
+  "count" should {
+    //same as dao.count
+    "work" in pending
+  }
+  "delete" should {
+    //same as dao.removeById
+    "remove standard" in new scope {
+      val standard = addStandard("subject-1", "category-1", "A.B.C")
+      service.delete(standard.id)
+      service.findOneById(standard.id) must_== None
+    }
+    "return true if standard has been removed" in new scope {
+      val standard = addStandard("subject-1", "category-1", "A.B.C")
+      service.delete(standard.id) must_== true
+    }
+    "return false if standard has not been removed" in new scope {
+      service.delete(ObjectId.get) must_== false
     }
   }
 
@@ -80,7 +70,7 @@ class StandardServiceTest extends ServicesSalatIntegrationTest with NoTimeConver
           Domain("ela-2", Seq("C.2"))),
         Seq.empty[Domain])
 
-      val result = services.standardService.domains
+      val result = service.domains
 
       val inner = Await.result(result, 2.seconds)
 
@@ -89,5 +79,85 @@ class StandardServiceTest extends ServicesSalatIntegrationTest with NoTimeConver
       result must equalTo(expected).await(timeout = 10.seconds)
     }
   }
+
+  "find" should {
+    //deprecated
+    "work" in pending
+  }
+
+  "findOne" should {
+    "find standard by id" in new scope {
+      val standard = addStandard("subject-1", "category-1", "A.B.C")
+      service.findOne(standard.id.toString) must_== Some(standard)
+    }
+    "return none if id is not an ObjectId" in new scope {
+      service.findOne("not an object id") must_== None
+    }
+    "return none if standard cannot be found" in new scope {
+      service.findOne(ObjectId.get.toString) must_== None
+    }
+  }
+
+  "findOneByDotNotation" should {
+    "find exactly matching standard by dot notation" in new scope {
+      val standard = addStandard("subject-1", "category-1", "A.B.C")
+      service.findOneByDotNotation("A.B.C") must_== Some(standard)
+    }
+    "return none if dotNotation does not match exactly" in new scope {
+      val standard = addStandard("subject-1", "category-1", "A.B.C")
+      service.findOneByDotNotation("A.") must_== None
+    }
+    "return none if dotNotation does not match any standard" in new scope {
+      val standard = addStandard("subject-1", "category-1", "A.B.C")
+      service.findOneByDotNotation("X.Y.Z") must_== None
+    }
+  }
+
+  "findOneById" should {
+    //same as dao.findOneById
+    "work" in pending
+  }
+
+  "insert" should {
+    //same as dao.insert
+    "work" in pending
+  }
+
+  "list" should {
+    //same as dao.find().skip.limit
+    "work" in pending
+  }
+
+  "query" should {
+    "return a list of standards, when term is found in dotNotation" in new scope {
+      val query = StandardQuery("C.1.2", None, None, None, None)
+      val stream = service.query(query, 0, 0)
+      stream.length === 1
+    }
+
+    "return an empty list of standards when term is found in dotNotation, but the category does not match" in new scope {
+      val query = StandardQuery("C.1", None, None, Some(Math), None)
+      val stream = service.query(query, 0, 0)
+      stream.length === 0
+    }
+
+    "return only standards, that exactly match the dotNotation" in new scope {
+      val query = StandardQuery("C.1", None, None, None, None)
+      val stream = service.query(query, 0, 0)
+      stream.length === 1
+    }
+  }
+
+  "queryDotNotation" should {
+    "exactly match the dotNotation" in new scope {
+      val stream = service.queryDotNotation("C.1", 0, 0)
+      stream.length === 1
+    }
+    "return empty stream if dotNotation does not match any standard" in new scope {
+      val stream = service.queryDotNotation("not a dot notation", 0, 0)
+      stream.length === 0
+    }
+  }
+
 }
 

--- a/modules/core/services-salat/src/main/scala/org/corespring/services/salat/StandardService.scala
+++ b/modules/core/services-salat/src/main/scala/org/corespring/services/salat/StandardService.scala
@@ -22,16 +22,6 @@ class StandardService(val dao: SalatDAO[Standard, ObjectId],
 
   override def findOneById(id: ObjectId): Option[Standard] = dao.findOneById(id)
 
-  private def getDomains(getDomain: Standard => Option[String], subjects: String*): Future[Seq[Domain]] = {
-    val query = Standard.Keys.Subject $in subjects
-    logger.trace(s"function=getDomains, query=$query")
-    val standards = Future { dao.find(query).toSeq }
-    standards.map { s =>
-      logger.trace(s"function=getDomains, query=$query, standards=$s, size=${s.size}")
-      Domain.fromStandards(s, _.subCategory)
-    }
-  }
-
   //Core Refactor: From Standard.Domains
   override lazy val domains: Future[StandardDomains] = {
     import Standard.{ Subjects }
@@ -59,6 +49,31 @@ class StandardService(val dao: SalatDAO[Standard, ObjectId],
     dao.find(query).skip(sk).limit(l).toStream
   }
 
+  override def query(q: StandardQuery, l: Int = 50, sk: Int = 0): Stream[Standard] = {
+    dao.find(toDbo(q)).limit(l).skip(sk).toStream
+  }
+
+  override def count(query: DBObject): Long = dao.count(query)
+
+  override def find(dbo: DBObject): Stream[Standard] = dao.find(dbo).toStream
+
+  override def insert(standard: Standard): Option[ObjectId] = dao.insert(standard, WriteConcern.Safe)
+
+  override def delete(id: ObjectId): Boolean = dao.removeById(id).getN == 1
+
+
+  private def getDomains(getDomain: Standard => Option[String], subjects: String*): Future[Seq[Domain]] = {
+    val query = Standard.Keys.Subject $in subjects
+    logger.trace(s"function=getDomains, query=$query")
+    val standards = Future { dao.find(query).toSeq }
+    standards.map { s =>
+      logger.trace(s"function=getDomains, query=$query, standards=$s, size=${s.size}")
+      Domain.fromStandards(s, _.subCategory)
+    }
+  }
+
+  private def toRegex(searchTerm: String) = MongoDBObject("$regex" -> searchTerm, "$options" -> "i")
+
   private def toDbo(q: StandardQuery): DBObject = {
 
     val l = List(
@@ -84,18 +99,6 @@ class StandardService(val dao: SalatDAO[Standard, ObjectId],
     query ++ or
   }
 
-  override def query(q: StandardQuery, l: Int = 50, sk: Int = 0): Stream[Standard] = {
-    dao.find(toDbo(q)).limit(l).skip(sk).toStream
-  }
 
-  private def toRegex(searchTerm: String) = MongoDBObject("$regex" -> searchTerm, "$options" -> "i")
-
-  override def count(query: DBObject): Long = dao.count(query)
-
-  override def find(dbo: DBObject): Stream[Standard] = dao.find(dbo).toStream
-
-  override def insert(standard: Standard): Option[ObjectId] = dao.insert(standard, WriteConcern.Safe)
-
-  override def delete(id: ObjectId): Boolean = dao.removeById(id).getN == 1
 
 }

--- a/modules/core/services/src/main/scala/org/corespring/services/StandardService.scala
+++ b/modules/core/services/src/main/scala/org/corespring/services/StandardService.scala
@@ -14,17 +14,11 @@ case class StandardQuery(term: String,
 
 trait StandardService extends QueryService[Standard, StandardQuery] {
 
-  def queryDotNotation(dotNotation: String, l: Int = 50, sk: Int = 0): Stream[Standard]
-
-  def delete(id: ObjectId): Boolean
-
-  def insert(standard: Standard): Option[ObjectId]
-
   def count(query: DBObject): Long
-
-  def findOneById(id: ObjectId): Option[Standard]
-
-  def findOneByDotNotation(dotNotation: String): Option[Standard]
-
+  def delete(id: ObjectId): Boolean
   def domains: Future[StandardDomains]
+  def findOneByDotNotation(dotNotation: String): Option[Standard]
+  def findOneById(id: ObjectId): Option[Standard]
+  def insert(standard: Standard): Option[ObjectId]
+  def queryDotNotation(dotNotation: String, l: Int = 50, sk: Int = 0): Stream[Standard]
 }


### PR DESCRIPTION
At the moment we cannot easily find standards with a prefix of a dotNotation. Don't we need that? 
Eg. C.1 should return C1., C1.1., C.1.2, ... 
