### PR TITLE
AC-206 add base query for contentType assessmentTemplate & test

### DIFF
--- a/modules/core/models/src/main/scala/org/corespring/models/assessment/AssessmentTemplate.scala
+++ b/modules/core/models/src/main/scala/org/corespring/models/assessment/AssessmentTemplate.scala
@@ -8,9 +8,8 @@ case class AssessmentTemplate(id: ObjectId = AssessmentTemplate.Defaults.id,
     orgId: Option[ObjectId] = AssessmentTemplate.Defaults.orgId,
     metadata: Map[String, String] = AssessmentTemplate.Defaults.metadata,
     dateModified: Option[DateTime] = AssessmentTemplate.Defaults.dateModified,
-    questions: Seq[Question] = AssessmentTemplate.Defaults.questions) {
-
-  var contentType = AssessmentTemplate.contentType
+    questions: Seq[Question] = AssessmentTemplate.Defaults.questions,
+    contentType: String = AssessmentTemplate.contentType) {
 
   def merge(that: AssessmentTemplate) = this.copy(
     collectionId = if (that.collectionId.nonEmpty) that.collectionId else this.collectionId,

--- a/modules/core/services-salat/src/it/scala/org/corespring/services/salat/assessment/AssessmentTemplateServiceTest.scala
+++ b/modules/core/services-salat/src/it/scala/org/corespring/services/salat/assessment/AssessmentTemplateServiceTest.scala
@@ -43,12 +43,17 @@ class AssessmentTemplateServiceTest extends ServicesSalatIntegrationTest {
   "findByOrg" should {
     "find template by the org" in new scope {
       service.insert(templateTwo)
-      val stream = service.findByOrg(orgOne.id)
+      val stream = service.findByOrg(orgTwo.id)
       stream.length must_== 1
-      stream(0).orgId must_== Some(orgOne.id)
+      stream(0).orgId must_== Some(orgTwo.id)
     }
     "return empty stream if org does not exist" in new scope {
       service.findByOrg(ObjectId.get) must_== Stream.empty
+    }
+    "return empty stream if contentType is not the default" in new scope {
+      val templateWithOtherType = templateTwo.copy(contentType="something other")
+      service.insert(templateWithOtherType)
+      service.findByOrg(orgTwo.id) must_== Stream.empty
     }
   }
 

--- a/modules/core/services-salat/src/main/scala/org/corespring/services/salat/assessment/AssessmentTemplateService.scala
+++ b/modules/core/services-salat/src/main/scala/org/corespring/services/salat/assessment/AssessmentTemplateService.scala
@@ -6,6 +6,7 @@ import com.novus.salat.Context
 import com.novus.salat.dao.SalatDAO
 import org.bson.types.ObjectId
 import org.corespring.models.assessment.AssessmentTemplate
+import org.corespring.models.assessment.AssessmentTemplate.Keys
 import org.corespring.services.salat.HasDao
 import org.joda.time.DateTime
 import org.corespring.{ services => interface }
@@ -16,12 +17,13 @@ class AssessmentTemplateService(
   extends interface.assessment.AssessmentTemplateService
   with HasDao[AssessmentTemplate, ObjectId] {
 
-  override def findByOrg(orgId: ObjectId): Stream[AssessmentTemplate] = dao.find(MongoDBObject("orgId" -> orgId)).toStream
+  override def findByOrg(orgId:ObjectId): Stream[AssessmentTemplate] =
+    baseFind(MongoDBObject(Keys.orgId -> orgId)).toStream
 
   override def findOneById(id: ObjectId): Option[AssessmentTemplate] = dao.findOneById(id)
 
   override def findOneByIdAndOrg(id: ObjectId, orgId: ObjectId): Option[AssessmentTemplate] =
-    dao.findOne(MongoDBObject("_id" -> id, "orgId" -> orgId))
+    dao.findOne(MongoDBObject("_id" -> id, Keys.orgId -> orgId))
 
   override def insert(assessmentTemplate: AssessmentTemplate): Option[ObjectId] = dao.insert(assessmentTemplate)
 
@@ -33,5 +35,13 @@ class AssessmentTemplateService(
       Left(result.getLastError.getErrorMessage)
     }
   }
+
+  private def baseAssessmentTemplateQuery: DBObject = MongoDBObject(Keys.contentType -> AssessmentTemplate.contentType)
+
+  private def baseFind(query: DBObject, fields: DBObject = new BasicDBObject(), limit: Int = 0, skip: Int = 0): Stream[AssessmentTemplate] = {
+    dao.find(new MongoDBObject(baseAssessmentTemplateQuery) ++ query, fields).limit(limit).skip(skip).toStream
+  }
+
+
 }
 


### PR DESCRIPTION
I just found out, that the assessment templates are stored in the content collection. This means we need check the contentType when retrieving objects via a query that doesn't have the id in it. 
I've added a base query for contentType=assessmentTemplate
