### PR TITLE
Add ability to override the app version to make it possible to test cdn

### DIFF
--- a/app/bootstrap/Main.scala
+++ b/app/bootstrap/Main.scala
@@ -110,7 +110,7 @@ object Main
 
     override lazy val bucket: String = AppConfig.assetsBucket
 
-    override def appVersion: String = BuildInfo.commitHashShort
+    override def appVersion: String = BuildInfo.commitHashShort + AppConfig.appVersionOverride
 
     override def s3: AmazonS3 = bootstrap.Main.s3
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -26,6 +26,10 @@ AMAZON_ACCESS_SECRET=${?ENV_AMAZON_ACCESS_SECRET}
 # This is only useful for test/dev environments
 AMAZON_ENDPOINT=${?ENV_AMAZON_ENDPOINT}
 
+# To make cdn testing easier
+# Simply change the version if you want to start with a fresh cdn cache
+APP_VERSION_OVERRIDE=${?APP_VERSION_OVERRIDE}
+
 # DynamoDb
 # Use Dynamo instead of the default (mongo)
 DYNAMO_DB_ACTIVATE=false

--- a/modules/lib/api-utils/src/main/scala/org/corespring/common/config/AppConfig.scala
+++ b/modules/lib/api-utils/src/main/scala/org/corespring/common/config/AppConfig.scala
@@ -10,7 +10,7 @@ class AppConfig(config: Configuration) {
 
   protected object Key extends Enumeration {
     type Key = Value
-    val ALLOW_ALL_SESSIONS, AMAZON_ACCESS_KEY, AMAZON_ACCESS_SECRET, AMAZON_ASSETS_BUCKET, AMAZON_ENDPOINT, DEMO_ORG_ID, DYNAMO_DB_ACTIVATE, DYNAMO_DB_LOCAL_INIT, DYNAMO_DB_LOCAL_PORT, DYNAMO_DB_USE_LOCAL, ELASTIC_SEARCH_URL, ENV_NAME, ROOT_ORG_ID, V2_PLAYER_ORG_IDS, COMPONENT_FILTERING_ENABLED, SESSION_SERVICE, SESSION_SERVICE_URL, SESSION_SERVICE_AUTHTOKEN = Value
+    val ALLOW_ALL_SESSIONS, AMAZON_ACCESS_KEY, AMAZON_ACCESS_SECRET, AMAZON_ASSETS_BUCKET, AMAZON_ENDPOINT, APP_VERSION_OVERRIDE, DEMO_ORG_ID, DYNAMO_DB_ACTIVATE, DYNAMO_DB_LOCAL_INIT, DYNAMO_DB_LOCAL_PORT, DYNAMO_DB_USE_LOCAL, ELASTIC_SEARCH_URL, ENV_NAME, ROOT_ORG_ID, V2_PLAYER_ORG_IDS, COMPONENT_FILTERING_ENABLED, SESSION_SERVICE, SESSION_SERVICE_URL, SESSION_SERVICE_AUTHTOKEN = Value
   }
 
   private implicit def keyToString(k: Key.Key): String = k.toString
@@ -21,6 +21,7 @@ class AppConfig(config: Configuration) {
   lazy val amazonSecret: String = config.getString(Key.AMAZON_ACCESS_SECRET).getOrElse("?")
   lazy val amazonEndpoint: Option[String] = config.getString(Key.AMAZON_ENDPOINT)
   lazy val assetsBucket: String = config.getString(Key.AMAZON_ASSETS_BUCKET).getOrElse("?")
+  lazy val appVersionOverride: String = config.getString(Key.APP_VERSION_OVERRIDE).getOrElse("")
   lazy val demoOrgId: ObjectId = config.getString(Key.DEMO_ORG_ID).map(new ObjectId(_)).getOrElse(throw new RuntimeException("Not found"))
   lazy val dynamoDbActivate: Boolean = config.getBoolean(Key.DYNAMO_DB_ACTIVATE).getOrElse(false)
   lazy val dynamoDbLocalInit: Boolean = config.getBoolean(Key.DYNAMO_DB_LOCAL_INIT).getOrElse(false)


### PR DESCRIPTION
The cache filter uses the commit hash of the current build to version the cdn assets 
Since this can only be changed by doing a new build, i've added an env var that allows you 
to manually change the appVersion, if you want to start  with a fresh cdn 

This is mainly for testing 
