### PR TITLE
add failing test (pending until fixed) and log failing token

### DIFF
--- a/it-resources/application-logger.xml
+++ b/it-resources/application-logger.xml
@@ -11,6 +11,8 @@
   <logger name="org.corespring.services.salat.ServicesContext" level="WARN"/>
   <logger name="org.corespring.services.salat.OrgCollectionService" level="WARN"/>
   <logger name="org.corespring.assets.EncodedKeyS3Client" level="WARN"/>
+  <logger name="org.corespring.v2.auth.identifiers.TokenOrgIdentity" level="DEBUG"/>
+  <logger name="org.corespring.it.helpers" level="TRACE"/>
 
   <root level="WARN">
     <appender-ref ref="STDOUT" />

--- a/it/org/corespring/it/helpers/AccessTokenHelper.scala
+++ b/it/org/corespring/it/helpers/AccessTokenHelper.scala
@@ -2,10 +2,23 @@ package org.corespring.it.helpers
 
 import global.Global.main
 import org.bson.types.ObjectId
+import org.corespring.services.auth.UpdateAccessTokenService
+import org.joda.time.DateTime
+import play.api.Logger
 
 object AccessTokenHelper {
 
+  lazy val logger = Logger(AccessTokenHelper.getClass)
   lazy val service = main.tokenService
+
+  def expire(tokenId: String) = {
+    val token = main.tokenService.findByTokenId(tokenId).get
+    val update = token.copy(expirationDate = DateTime.now.minusDays(1))
+
+    logger.info(s"function=expire, update=$update")
+
+    main.tokenService.asInstanceOf[UpdateAccessTokenService].update(update)
+  }
 
   def create(organizationId: ObjectId): String = {
     val client = main.apiClientService.getOrCreateForOrg(organizationId).toOption.get

--- a/it/org/corespring/v2/AccessTokenIntegrationTest.scala
+++ b/it/org/corespring/v2/AccessTokenIntegrationTest.scala
@@ -1,0 +1,33 @@
+package org.corespring.v2
+
+import org.corespring.it.IntegrationSpecification
+import org.corespring.it.helpers.AccessTokenHelper
+import org.corespring.it.scopes.{ TokenRequestBuilder, orgWithAccessTokenAndItem }
+import org.specs2.specification.Scope
+
+class AccessTokenIntegrationTest extends IntegrationSpecification {
+
+  val routes = org.corespring.v2.api.routes.ItemApi
+
+  "access token" should {
+
+    "ItemApi.get" should {
+
+      trait scope
+        extends Scope
+        with orgWithAccessTokenAndItem
+        with TokenRequestBuilder {
+      }
+
+      s"return $BAD_REQUEST - for an access token that has expired" in new scope {
+        AccessTokenHelper.expire(accessToken)
+        lazy val call = routes.get(itemId.toString)
+        lazy val req = makeRequest(call)
+        lazy val result = route(req).get
+        status(result) must_== BAD_REQUEST
+      }.pendingUntilFixed("AC-320")
+    }
+  }
+
+}
+

--- a/modules/core/services/src/main/scala/org/corespring/services/auth/AccessTokenService.scala
+++ b/modules/core/services/src/main/scala/org/corespring/services/auth/AccessTokenService.scala
@@ -6,6 +6,10 @@ import org.corespring.models.auth.{ AccessToken, ApiClient }
 
 import scalaz.Validation
 
+trait UpdateAccessTokenService {
+  def update(token: AccessToken): Validation[PlatformServiceError, AccessToken]
+}
+
 trait AccessTokenService {
   def removeToken(tokenId: String): Validation[PlatformServiceError, Unit]
 


### PR DESCRIPTION
### Release Notes
#### Context

We found a bug where for some endpoints (`/api/v2`) an expired token was able to successfully authenticate.
#### Change (Breaking: No)

If an expired token is used, an error will be raised in our logs. We'll track these errors and alert the 3rd party that they need to update their code. Once the error no longer appears in our logs we'll create a new release with a breaking change, where we'll not allow expired tokens to work anymore.
