### PR TITLE
add trigger-component-sets plugin

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -273,6 +273,7 @@ object Build extends sbt.Build {
     .settings(ComponentsBuilder.settings: _*)
     .settings(Indexing.indexTask)
     .settings(AccessToken.cleanupTask)
+    .enablePlugins(org.corespring.triggerComponentSets.TriggerComponentSetsPlugin)
     .addBuildInfo()
     .dependsOn(
       apiUtils,

--- a/project/trigger-component-sets.sbt
+++ b/project/trigger-component-sets.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.corespring" %% "trigger-component-sets" % "1.0.0")


### PR DESCRIPTION
Add the [trigger-component-sets](/corespring/trigger-component-sets) plugin: 

`play "triggerComponentSets --heroku corespring-app-qa --limit 2000"`

Will check in w/ @benka about giving it a run against a new deploy to see if it helps speed up player launching.
