### PR TITLE
use s3-play-plugin@2.0.0

### DIFF
--- a/modules/lib/v2-player-integration/src/main/scala/org/corespring/v2/player/hooks/DraftEditorHooks.scala
+++ b/modules/lib/v2-player-integration/src/main/scala/org/corespring/v2/player/hooks/DraftEditorHooks.scala
@@ -163,15 +163,13 @@ class DraftEditorHooks(
       encodingHelper.encodedOnce(s)
     }
 
-    playS3.s3ObjectAndData[ItemDraft](awsConfig.bucket, d => {
+    playS3.uploadWithData[ItemDraft](awsConfig.bucket, d => {
       val p = S3Paths.draftFile(d.id, path)
       urlEncode(p)
     })(loadDraftPredicate).map { f =>
       f.map { tuple =>
-        val (s3Object, draft) = tuple
-        val key = s3Object.getKey
-        addFileToData(draft, key)
-        IOUtils.closeQuietly(s3Object)
+        val (upload, draft) = tuple
+        addFileToData(draft, upload.key)
         UploadResult(urlEncode(path))
       }
     }

--- a/modules/lib/v2-player-integration/src/main/scala/org/corespring/v2/player/hooks/ItemEditorHooks.scala
+++ b/modules/lib/v2-player-integration/src/main/scala/org/corespring/v2/player/hooks/ItemEditorHooks.scala
@@ -151,7 +151,7 @@ class ItemEditorHooks(
       encodingHelper.encodedOnce(s)
     }
 
-    playS3.s3ObjectAndData[Item](bucket, i => {
+    playS3.uploadWithData[Item](bucket, i => {
 
       if (i.id.version.isEmpty) {
         logger.warn(s"[upload] The id is missing a version: ${i.id}")
@@ -161,10 +161,8 @@ class ItemEditorHooks(
       urlEncode(p)
     })(loadItemPredicate).map { f =>
       f.map { tuple =>
-        val (s3Object, item) = tuple
-        val key = s3Object.getKey
-        addFileToData(item, key)
-        IOUtils.closeQuietly(s3Object)
+        val (upload, item) = tuple
+        addFileToData(item, upload.key)
         UploadResult(urlEncode(path))
       }
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val playMemcached = "com.github.mumoshu" %% "play2-memcached" % "0.4.0"
   val playPluginMailer = "com.typesafe" %% "play-plugins-mailer" % "2.2.0"
   val playPluginUtil = "com.typesafe" %% "play-plugins-util" % "2.2.0"
-  val playS3 = "org.corespring" %% "s3-play-plugin" % "1.2.1"
+  val playS3 = "org.corespring" %% "s3-play-plugin" % "2.0.0"
   val playTest = "com.typesafe.play" %% "play-test" % playVersion
   val qti = "org.corespring" %% "corespring-qti" % qtiVersion
   val qtiConverter = "org.corespring" %% "qti-corespring-converter" % qtiVersion

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "7.9.1-SNAPSHOT"
+version in ThisBuild := "7.9.2-SNAPSHOT"


### PR DESCRIPTION
`2.0.0` of play plugin handles upload failures (used by the Item and Draft editor), preventing a future being returned but never resolving. We suspect that this hanging may cause the app to consume threads and cause hanging once the thread pool is all caught up by the `TransferManager`

@see https://github.com/corespring/s3-play-plugin/pull/6